### PR TITLE
Add GitHub Pages deployment workflow and live demo link

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install Trunk
+        run: cargo install trunk --locked
+
+      - name: Build
+        run: trunk build --release --public-url /sdfer/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ sdfer aims to become a script based CAD.
 It runs in the browser, using WASM + WebGL + Shaders.
 It is based on implicit functions as described in depth by [iq](https://iquilezles.org/articles/distfunctions/).
 
+**[Live Demo](https://hmeyer.github.io/sdfer/)**
+
 ## Examples
 
 During development I focused on creating platonics, archimedean and catalan solids.


### PR DESCRIPTION
## Summary
This PR adds continuous deployment to GitHub Pages and updates the README with a link to the live demo.

## Key Changes
- **Added GitHub Actions workflow** (`.github/workflows/pages.yml`):
  - Automatically builds and deploys the project to GitHub Pages on pushes to `main`
  - Installs Rust toolchain with WebAssembly target support
  - Caches Cargo dependencies for faster builds
  - Builds the project using Trunk with release optimizations
  - Deploys the built artifacts to GitHub Pages

- **Updated README.md**:
  - Added a prominent link to the live demo at https://hmeyer.github.io/sdfer/

## Implementation Details
- The workflow uses `trunk build --release --public-url /sdfer/` to build the WebAssembly project with the correct public URL for the GitHub Pages subdirectory
- Cargo caching is configured to speed up subsequent builds
- The deployment uses GitHub's official `actions/deploy-pages@v4` action for secure and reliable deployment
- Manual workflow dispatch is enabled for on-demand deployments

https://claude.ai/code/session_01ArqQb1ePUNZHyFqwPtbeyd