### PR TITLE
Add CI workflow and badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Test
+        run: cargo test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # sdfer
+
+[![CI](https://github.com/hmeyer/sdfer/actions/workflows/ci.yml/badge.svg)](https://github.com/hmeyer/sdfer/actions/workflows/ci.yml)
+
 sdfer aims to become a script based CAD.
 It runs in the browser, using WASM + WebGL + Shaders.
 It is based on implicit functions as described in depth by [iq](https://iquilezles.org/articles/distfunctions/).


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions continuous integration workflow to automatically build and test the project on pull requests and pushes to main.

## Key Changes
- **Added `.github/workflows/ci.yml`**: New CI workflow that:
  - Runs on pull requests and pushes to the main branch
  - Installs Rust with the `wasm32-unknown-unknown` target for WebAssembly builds
  - Caches Cargo dependencies to speed up subsequent runs
  - Builds the project as a WebAssembly release binary
  - Runs the test suite
  
- **Updated `README.md`**: Added a CI status badge linking to the workflow runs

## Implementation Details
The workflow uses:
- `dtolnay/rust-toolchain@stable` for reliable Rust installation with WASM target support
- `actions/cache@v4` to cache cargo registry, git dependencies, and build artifacts based on `Cargo.lock` hash
- Release mode build for WebAssembly to optimize the final binary

https://claude.ai/code/session_016PdHppBC7XK9XvNZjk3zve