### PR TITLE
Add getrandom v0.3 with wasm_js backend for WebAssembly support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -495,6 +497,7 @@ dependencies = [
  "array_tool",
  "console_log",
  "getrandom 0.2.8",
+ "getrandom 0.3.4",
  "isosurface",
  "js-sys",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4"
 console_log = { version = "1.0", optional = true }
 nalgebra-glm = "0.20"
 getrandom = { version = "0.2", features = ["js"] }  # required for rhai
+getrandom_v03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
 rhai = { version = "1.24.0", features = ["only_i32", "f32_float", "no_closure", "no_custom_syntax"] }
 parking_lot = "0.12"
 anyhow = "1.0"


### PR DESCRIPTION
## Summary
This PR adds support for WebAssembly targets by introducing getrandom v0.3 with the `wasm_js` backend alongside the existing v0.2 dependency.

## Key Changes
- Added `.cargo/config.toml` with target-specific rustflags to configure the `wasm_js` backend for `wasm32-unknown-unknown` targets
- Added `getrandom_v03` dependency (getrandom v0.3) with `wasm_js` feature enabled in `Cargo.toml`
- Maintained existing getrandom v0.2 dependency for non-WebAssembly targets

## Implementation Details
The configuration uses Cargo's target-specific settings to ensure the correct getrandom backend is selected when compiling for WebAssembly. The v0.3 version with `wasm_js` feature provides proper random number generation in browser/WASM environments, while v0.2 continues to be used for other platforms.

https://claude.ai/code/session_01FHnRkAsiwTiDPvTuxP5kt7